### PR TITLE
add systemd-binfmt restart failure warning

### DIFF
--- a/create-deb.sh
+++ b/create-deb.sh
@@ -76,9 +76,12 @@ for target in ${targets[@]}; do
   cp ../docs/USAGE.md ./doc-pak || error "Failed to add USAGE to docs"
   cp ../LICENSE ./doc-pak || error "Failed to add LICENSE to docs"
   echo "Box64 lets you run x86_64 Linux programs (such as games) on non-x86_64 Linux systems, like ARM (host system needs to be 64bit little-endian)">description-pak || error "Failed to create description-pak."
-  echo "#!/bin/bash
-  echo 'Restarting systemd-binfmt...'
-  systemctl restart systemd-binfmt || true" > postinstall-pak || error "Failed to create postinstall-pak!"
+  echo '#!/bin/bash
+warning() { #yellow text
+  echo -e "\e[93m\e[5m◢◣\e[25m WARNING: $1\e[0m" 1>&2
+}
+echo "Restarting systemd-binfmt..."
+systemctl restart systemd-binfmt || warning "Restarting systemd-binfmt failed. This means Box64 will not be automatically summoned to run x86_64 code, breaking some apps that use it including Steam."' > postinstall-pak || error "Failed to create postinstall-pak!"
 
   conflict_list="qemu-user-static, box64, box64-generic-arm-page16k"
   for value in "${targets[@]}"; do


### PR DESCRIPTION
Adds back the informative error introduced in the old commit https://github.com/Botspot/pi-apps/commit/4e53be4bef298b15c3823ba91f0794ab70a54fa6
Should help future chromebook users and anyone else without the systemd-binfmt service installed.

This is a PR in case you can think of plausible situations where this warning would be a false positive. (cases where binfmt works but the binfmt service still fails to restart)
If all looks good, then I will commit an equivalent change to the box86-debs repo.