### PR TITLE
enable box32 & wowbox64 for tegra

### DIFF
--- a/create-deb.sh
+++ b/create-deb.sh
@@ -51,6 +51,8 @@ for target in ${targets[@]}; do
     cmake .. -DBAD_SIGNAL=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc-8 -DARM_DYNAREC=ON || error "Failed to run cmake."
   elif [[ $target == "GENERIC_ARM" ]]; then
     cmake .. -DARM64=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc-8 -DARM_DYNAREC=ON || error "Failed to run cmake."
+  elif [[ $target == "TEGRAX1" ]]; then
+    cmake .. -D$target=1 -DBOX32=ON -DBOX32_BINFMT=ON -DWOW64=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc-8 -DARM_DYNAREC=ON || error "Failed to run cmake."
   else
     cmake .. -D$target=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc-8 -DARM_DYNAREC=ON || error "Failed to run cmake."
   fi


### PR DESCRIPTION
untested, this is mostly just to get a conversation going. the lack of 32-bit graphics drivers from Nvidia for L4T platforms makes this, in my opinion, kind of a no-brainer - but I'm not sure how far along the support for these particular features actually is in practice.